### PR TITLE
Remove "xxx" Opaki-interface dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
       }
     ],
     "okapiInterfaces": {
-      "xxx": "99.9"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
Should allow the generated module descriptor to be loaded into Okapi.

Obviously this will come back when I figure out the correct dependencies.