### PR TITLE
[UIINIMP-3] Correctly display embedded list of steps in pipeline

### DIFF
--- a/src/settings/PipelineDetail.js
+++ b/src/settings/PipelineDetail.js
@@ -31,18 +31,14 @@ const PipelineDetail = (props) => {
 
       <h3><FormattedMessage id="ui-inventory-import.settings.step" /></h3>
       <MultiColumnList
-        visibleColumns={['position', 'name', 'in', 'out']}
+        visibleColumns={['position', 'name']}
         columnMapping={{
           position: <FormattedMessage id="ui-inventory-import.pipeline.steps.position" />,
           name: <FormattedMessage id="ui-inventory-import.pipeline.steps.name" />,
-          in: <FormattedMessage id="ui-inventory-import.pipeline.steps.in" />,
-          out: <FormattedMessage id="ui-inventory-import.pipeline.steps.out" />,
         }}
         contentData={data.steps}
         formatter={{
-          name: r => r.step.name,
-          in: r => r.step.inputFormat,
-          out: r => r.step.outputFormat,
+          position: r => r.rowIndex + 1,
         }}
       />
 

--- a/translations/ui-inventory-import/en.json
+++ b/translations/ui-inventory-import/en.json
@@ -292,8 +292,6 @@
     "pipeline.field.steps": "Transformation steps",
     "pipeline.steps.position": "#",
     "pipeline.steps.name": "Name",
-    "pipeline.steps.in": "In",
-    "pipeline.steps.out": "Out",
     "pipeline.steps.actions": "Actions",
     "step.field.name": "Name",
     "step.field.description": "Description",


### PR DESCRIPTION
This is part of UIINIMP-3, the bulk of which was done a few commits ago. This tweak is necessary because, now that we're getting a list of steps back as part of the pipeline, the display logic needed minor changes.