### PR TITLE
Fix ReDoS in FullChannel.js

### DIFF
--- a/src/views/FullChannel.js
+++ b/src/views/FullChannel.js
@@ -17,7 +17,7 @@ const FullChannel = ({ defaultWidth, resources, mutator, match, deleteRecord }) 
 
   const returnToList = () => {
     const currentPath = match.url;
-    const newPath = currentPath.replace(/(.*)\/.*./, '$1');
+    const newPath = currentPath.replace(/^(.*)\/.+/, '$1');
     mutator.query.update({ _path: `${newPath}` });
   };
 


### PR DESCRIPTION
Sonar report:
https://sonarcloud.io/project/security_hotspots?id=org.folio%3Aui-inventory-import&hotspots=AZxnljAvV8Psla8h9KdM

`/(.*)\/.*./` has quadratic runtime if it doesn't match because it lacks the left anchor. Fix:

`/^(.*)\/.*./`

Merging `.*.` to `.+` increases readability (and avoids a one character back-track):

`/^(.*)\/.+/`