### PR TITLE
Fix ReDoS in message2stats.js

### DIFF
--- a/src/util/message2stats.js
+++ b/src/util/message2stats.js
@@ -3,7 +3,7 @@ function message2stats(message) {
   if (!message || message === 'No records harvested') return stats;
 
   message.split(' ').forEach(row => {
-    const matchData = row.match(/(.*?)_.*:_+([^_]*)_+([^_]*)_+([^_]*)_+([^_]*)/);
+    const matchData = row.match(/^([^_]*)_[^:]*:_+([^_]+)_+([^_]+)_+([^_]+)_+([^_]+)/);
     if (matchData) {
       // eslint-disable-next-line no-unused-vars
       const [_matched, name, processed, loaded, deleted, failed] = matchData;


### PR DESCRIPTION
Sonar report:
https://sonarcloud.io/project/security_hotspots?id=org.folio%3Aui-inventory-import&hotspots=AZxnljAvV8Psla8h9KdM

`/(.*?)_.*:_+([^_]*)_+([^_]*)_+([^_]*)_+([^_]*)/` has quadratic or worse runtime. Fix:

`/^([^_]*)_[^:]*:_+([^_]+)_+([^_]+)_+([^_]+)_+([^_]+)/`

* Use left anchor.
* Use the following delimiting character to construct a negated character class.
* Require at least one (not zero) non `_` character between two delimiting `_` characters.