### PR TITLE
Fix ReDoS in renderDateFilterPair.js

### DIFF
--- a/src/search/renderDateFilterPair.js
+++ b/src/search/renderDateFilterPair.js
@@ -10,7 +10,7 @@ import { deparseFilters } from '@folio/stripes/smart-components';
 function renderSingleDateFilter(intl, filterStruct, updateQuery, field, boundary) {
   const keyString = `${field}_${boundary}`;
   const rawValue = filterStruct[keyString]?.[0];
-  const value = !rawValue ? '' : rawValue.replace(/.*[<>]=/, '');
+  const value = !rawValue ? '' : rawValue.replace(/^.*[<>]=/, '');
 
   return (
     <Datepicker


### PR DESCRIPTION
Sonar report about the ReDoS:
https://sonarcloud.io/project/security_hotspots?id=org.folio%3Aui-inventory-import&hotspots=AZxnljCeV8Psla8h9Kd1

`/.*[<>]=/` has quadratic runtime if there's no match because of the missing left anchor. Solution:

`/^.*[<>]=/`