### PR TITLE
Fix ReDoS in renderFilter.js

### DIFF
--- a/src/search/renderFilter.js
+++ b/src/search/renderFilter.js
@@ -12,7 +12,7 @@ function renderFilter(intl, filterStruct, updateQuery, qualifiedField, optionTag
   // they are elsewhere, `qualifiedField` takes the form `FIELD/TAG`
   // where TAG is the translation-tag path to the relevant field's
   // translations. See JobsSearchPane.js for examples.
-  const match = qualifiedField.match(/(.*)\/(.*)/);
+  const match = qualifiedField.match(/^(.*)\/(.*)$/);
   const field = match ? match[1] : qualifiedField;
   const transTag = match ? match[2] : `channels.column.${field}`;
   // console.log(`qualifiedField='${qualifiedField}' => field '${field}', transTag '${transTag}'`);


### PR DESCRIPTION
Sonar report:
https://sonarcloud.io/project/security_hotspots?id=org.folio%3Aui-inventory-import&hotspots=AZxnljCHV8Psla8h9Kdx

`/(.*)\/(.*)/` has quadratic runtime of there's no match because there's no left anchor. Solution:

`/^(.*)\/(.*)/`