### PR TITLE
Fix ReDoS in renderNumericFilterPair.js

### DIFF
--- a/src/search/renderNumericFilterPair.js
+++ b/src/search/renderNumericFilterPair.js
@@ -6,7 +6,7 @@ import { deparseFilters } from '@folio/stripes/smart-components';
 function renderSingleNumericFilter(intl, filterStruct, updateQuery, field, boundary) {
   const keyString = `${field}_${boundary}`;
   const rawValue = filterStruct[keyString]?.[0];
-  const value = !rawValue ? '' : rawValue.replace(/.*[<>]=/, '');
+  const value = !rawValue ? '' : rawValue.replace(/^.*[<>]=/, '');
 
   return (
     <TextField


### PR DESCRIPTION
Sonar report:
https://sonarcloud.io/project/security_hotspots?id=org.folio%3Aui-inventory-import&hotspots=AZxnljCAV8Psla8h9Kdv

`/.*[<>]=/` has quadratic runtime if it doesn't match because it has no left anchor. Solution:

`/^.*[<>]=/`