### PR TITLE
[IUINIMP-20] Rename `records` resource to `failedRecords`

### DIFF
--- a/src/routes/RecordsRoute.js
+++ b/src/routes/RecordsRoute.js
@@ -23,15 +23,18 @@ const RecordsRoute = ({ stripes, resources, mutator, children }) => {
     source.fetchOffset(index);
   };
 
-  const hasLoaded = resources.records.hasLoaded;
-  const error = resources.records.failed ? resources.records.failed.message : undefined;
+  // eslint-disable-next-line no-console
+  console.log('RecordsRoute: resources =', resources);
+
+  const hasLoaded = resources.failedRecords.hasLoaded;
+  const error = resources.failedRecords.failed ? resources.failedRecords.failed.message : undefined;
 
   return (
     <Records
       data={{
-        records: resources.records.records,
+        records: resources.failedRecords.records,
       }}
-      resultCount={resources.records.other?.totalRecords}
+      resultCount={resources.failedRecords.other?.totalRecords}
       query={resources.query}
       updateQuery={mutator.query.update}
       hasLoaded={hasLoaded}
@@ -64,7 +67,7 @@ RecordsRoute.manifest = Object.freeze({
   query: {},
   resultCount: { initialValue: INITIAL_RESULT_COUNT },
   resultOffset: { initialValue: 0 },
-  records: {
+  failedRecords: {
     type: 'okapi',
     path: 'inventory-import/failed-records',
     throwErrors: false,
@@ -101,7 +104,7 @@ RecordsRoute.propTypes = {
   }).isRequired,
   resources: PropTypes.shape({
     query: PropTypes.object.isRequired,
-    records: PropTypes.shape({
+    failedRecords: PropTypes.shape({
       failed: PropTypes.oneOfType([
         PropTypes.bool,
         PropTypes.shape({


### PR DESCRIPTION
I can't explain this, but it _seems_ to prevent to occasional error where stripes-connect gives us an empty `records` entry in the `resource` prop.

One can just about imagine stripes-connect getting confused about a resource called `records` with a member called `records`, but it's thin. I struggle to imagine why this would be an intermittent error.

Still, it's hard to imagine _any_ rational explanation for the behaviour we're seeing, so there's that.

Anyway, I have left in the console-logging of the `resources` object, so that if this manifests again we'll be able to see it happening.