### PR TITLE
[UIINIMP-57] Fix negative file-queue count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory-import
 
+## [4.1.1](https://github.com/folio-org/ui-inventory-import/tree/v4.1.1) (IN PROGRESS)
+
+* [UIINIMP-57](https://folio-org.atlassian.net/browse/UIINIMP-57) The number of files queued shows as `<NoValue>` rather than -1 when the channel is not commissioned.
+
 ## [4.1.0](https://github.com/folio-org/ui-inventory-import/tree/v4.1.0) (2026-04-16)
 
 * [UIINIMP-11](https://folio-org.atlassian.net/browse/UIINIMP-11) Align permissions names with Eureka conventions.

--- a/src/components/CKV.js
+++ b/src/components/CKV.js
@@ -4,12 +4,16 @@ import get from 'lodash/get';
 import { FormattedMessage } from 'react-intl';
 import { Row, Col, KeyValue } from '@folio/stripes/components';
 
-export const CKV = ({ rec, tag, i18nTag, xs }) => {
+export const CKV = ({ rec, tag, i18nTag, xs, formatFn = x => x }) => {
   let value = get(rec, tag);
   if (value === true) {
     value = '✅';
   } else if (value === false) {
     value = '❌';
+  }
+
+  if (formatFn) {
+    value = formatFn(value);
   }
 
   return (

--- a/src/views/FullChannel.js
+++ b/src/views/FullChannel.js
@@ -2,7 +2,7 @@ import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { CalloutContext, IfPermission, useStripes, useOkapiKy } from '@folio/stripes/core';
-import { Loading, Pane, Row, Col, KeyValue, NoValue, Accordion, Button, Icon, ConfirmationModal, Modal } from '@folio/stripes/components';
+import { Loading, Pane, Row, NoValue, Accordion, Button, Icon, ConfirmationModal, Modal } from '@folio/stripes/components';
 import { FileUploader } from '@folio/stripes-data-transfer-components';
 import { RCKV, CKV } from '../components/CKV';
 
@@ -192,12 +192,12 @@ const FullChannel = ({ defaultWidth, resources, mutator, match, deleteRecord }) 
       </Row>
       <RCKV rec={resources.transformationPipeline} tag="records[0].name" i18nTag="transformationPipeline" />
       <Row>
-        <Col xs={4}>
-          <KeyValue
-            label={<FormattedMessage id="ui-inventory-import.channels.field.queuedFiles" />}
-            value={rec.queuedFiles < 0 ? <NoValue /> : rec.queuedFiles}
-          />
-        </Col>
+        <CKV
+          rec={rec}
+          tag="queuedFiles"
+          xs={4}
+          formatFn={(val) => (val < 0 ? <NoValue /> : val)}
+        />
         <CKV rec={rec} tag="fileInProcess" xs={8} />
       </Row>
       {stripes.config.showDevInfo &&

--- a/src/views/FullChannel.js
+++ b/src/views/FullChannel.js
@@ -2,7 +2,7 @@ import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { CalloutContext, IfPermission, useStripes, useOkapiKy } from '@folio/stripes/core';
-import { Loading, Pane, Row, Accordion, Button, Icon, ConfirmationModal, Modal } from '@folio/stripes/components';
+import { Loading, Pane, Row, Col, KeyValue, NoValue, Accordion, Button, Icon, ConfirmationModal, Modal } from '@folio/stripes/components';
 import { FileUploader } from '@folio/stripes-data-transfer-components';
 import { RCKV, CKV } from '../components/CKV';
 
@@ -192,7 +192,12 @@ const FullChannel = ({ defaultWidth, resources, mutator, match, deleteRecord }) 
       </Row>
       <RCKV rec={resources.transformationPipeline} tag="records[0].name" i18nTag="transformationPipeline" />
       <Row>
-        <CKV rec={rec} tag="queuedFiles" xs={4} />
+        <Col xs={4}>
+          <KeyValue
+            label={<FormattedMessage id="ui-inventory-import.channels.field.queuedFiles" />}
+            value={rec.queuedFiles < 0 ? <NoValue /> : rec.queuedFiles}
+          />
+        </Col>
         <CKV rec={rec} tag="fileInProcess" xs={8} />
       </Row>
       {stripes.config.showDevInfo &&


### PR DESCRIPTION
When a channel is not commissioned, mod-inventory-update reports the `queuedFiles` as -1. That's fine as a special value for software to interpret, but makes no sense as a display value for humans. This is now displayed as `<NoValue>`.