### PR TITLE
UIINIMP-59 correctly import ObjectInspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIINIMP-57](https://folio-org.atlassian.net/browse/UIINIMP-57) The number of files queued shows as `<NoValue>` rather than -1 when the channel is not commissioned.
 * [UIINIMP-50](https://folio-org.atlassian.net/browse/UIINIMP-50) In the Jobs list, the ID column can no longer be hidden.
+* [UIINIMP-59](https://folio-org.atlassian.net/browse/UIINIMP-59) Correctly import ObjectInspector..
 
 ## [4.1.0](https://github.com/folio-org/ui-inventory-import/tree/v4.1.0) (2026-04-16)
 

--- a/src/views/ChannelLog/ChannelLogFailedRecords.js
+++ b/src/views/ChannelLog/ChannelLogFailedRecords.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import ObjectInspector from 'react-inspector';
+import { ObjectInspector } from 'react-inspector';
 import { useStripes } from '@folio/stripes/core';
 import { Loading, MultiColumnList, Accordion } from '@folio/stripes/components';
 import { errors2react } from '../../util/summarizeErrors';


### PR DESCRIPTION
Build logs indicate `ObjectInspector` is only available as a named export, not a default:
```
WARNING in ./node_modules/@folio/inventory-import/src/views/ChannelLog/ChannelLogFailedRecords.js 72:14-29
export 'default' (imported as 'ObjectInspector') was not found in 'react-inspector' (possible exports: Inspector, ObjectInspector, ObjectLabel, ObjectName, ObjectPreview, ObjectRootLabel, ObjectValue, TableInspector, chromeDark, chromeLight)
 @ ./node_modules/@folio/inventory-import/src/views/FullJob.js 30:0-75 186:28-51
 @ ./node_modules/@folio/inventory-import/src/routes/FullJobRoute.js 4:0-39 9:4-11
 @ ./node_modules/@folio/inventory-import/src/index.js 27:0-49 55:183-195
 @ ./node_modules/stripes-config.js
```

CC: @MikeTaylor since I don't have commit-privileges in this repository, can you review and merge this PR if it's acceptable to you? Thank you!

Refs [UIINIMP-59](https://folio-org.atlassian.net/browse/UIINIMP-59)