### PR TITLE
[UIINIMP-62] Remove "(All)" search from Channels page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inventory-import
 
+## [4.1.2](https://github.com/folio-org/ui-inventory-import/tree/v4.1.2) (IN PROGRESS)
+
+* [UIINIMP-62](https://folio-org.atlassian.net/browse/UIINIMP-62) Remove "(All)" search in Channels, default to "Name".
+
 ## [4.1.1](https://github.com/folio-org/ui-inventory-import/tree/v4.1.1) (2026-05-08)
 
 * [UIINIMP-57](https://folio-org.atlassian.net/browse/UIINIMP-57) The number of files queued shows as `<NoValue>` rather than -1 when the channel is not commissioned.

--- a/src/routes/ChannelsRoute.js
+++ b/src/routes/ChannelsRoute.js
@@ -40,9 +40,6 @@ function ChannelsRoute({ stripes, resources, mutator, children, defaultSearchPan
 }
 
 
-// Keep these in sync with what's in ../search/ChannelsSearchPane.js
-const searchableIndexes = ['name', 'id'];
-
 const filterConfig = [{
   name: 'enabled',
   cql: 'enabled',
@@ -70,7 +67,7 @@ ChannelsRoute.manifest = Object.freeze({
       query: (qp, pathComponents, rv, logger) => {
         const queryFunction = makeQueryFunction(
           'cql.allRecords=1',
-          searchableIndexes.map(index => `${index}="${qp.query}"`).join(' or '),
+          '*** cannot happen ***',
           {},
           filterConfig,
           0,
@@ -84,6 +81,12 @@ ChannelsRoute.manifest = Object.freeze({
         if (!rv.query || !rv.query.sort) {
           // eslint-disable-next-line no-param-reassign
           rv = { ...rv, query: { ...rv.query, sort: 'name' } };
+        }
+
+        // Default index when none is specified (UIINIMP-62)
+        if (!rv.query || !rv.query.qindex) {
+          // eslint-disable-next-line no-param-reassign
+          rv = { ...rv, query: { ...rv.query, qindex: 'name' } };
         }
 
         return queryFunction(qp, pathComponents, rv, logger);
@@ -120,7 +123,10 @@ ChannelsRoute.propTypes = {
       update: PropTypes.func.isRequired,
     }).isRequired,
   }).isRequired,
-  children: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+  ]),
 };
 
 

--- a/src/search/ChannelsSearchPane.js
+++ b/src/search/ChannelsSearchPane.js
@@ -30,7 +30,7 @@ function ChannelsSearchPane(props) {
       <form onSubmit={onSubmitSearch}>
         <MainSearchArea
           type="channels"
-          indexes={['', 'name', 'id']}
+          indexes={['name', 'id']}
           searchValue={searchValue}
           searchField={searchField}
           getSearchHandlers={getSearchHandlers}


### PR DESCRIPTION
This avoids an ugly error message caused by the back-end complaining if a non-UUID-formatted term is submitted in a query that includes the `id` index. Since no-one is likely to search on ID anyway, there's not much value in even trying to retain it. People who really want to search channels by ID for some reason can still do so using the "ID" index.